### PR TITLE
fix(docs): Doc-related links were broken

### DIFF
--- a/_layouts/default.liquid
+++ b/_layouts/default.liquid
@@ -22,8 +22,8 @@
         <div class="secondary">
           <h2>A static site generator written in Rust</h2>
           <nav>
-            <a href="#getting-started" class="button install"><span>Install</span></a>
-            <a href="#" class="button docs"><span>Docs</span></a>
+            <a href="/#getting-started" class="button install"><span>Install</span></a>
+            <a href="/docs" class="button docs"><span>Docs</span></a>
             <a href="/contributing.html" class="button contrib">
               <span>Contribute</span>
             </a>


### PR DESCRIPTION
A user couldn't get to the docs and I doubt they could then get back to
the "install" page.