### PR TITLE
Added a new Tools page with the cobalt.el package link.

### DIFF
--- a/_layouts/docs.liquid
+++ b/_layouts/docs.liquid
@@ -34,6 +34,7 @@
             <p>Misc</p>
             <ul>
               <li><a {% if page.data.route == "rss"%}class="active"{%endif%} href="/docs/rss.html">RSS</a></li>
+	      <li><a {% if page.data.route == "tools"%}class="active"{%endif%} href="/docs/tools.html">Tools</a></li>
               <li><a {% if page.data.route == "deployment"%}class="active"{%endif%} href="/docs/deployment.html">Deployment</a></li>
               <li><a {% if page.data.route == "trouble"%}class="active"{%endif%} href="/docs/trouble.html">Troubleshooting</a></li>
             </ul>

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,0 +1,9 @@
+title: "Docs::Tools"
+layout: docs.liquid
+data:
+  route: tools
+---
+## Tools
+
+### Cobalt for Emacs
+[Cobalt.el](https://github.com/accidentalrebel/cobalt.el) is an [Emacs](https://www.gnu.org/software/emacs/) interface for Cobalt. The package provides simple-to-use commands for easy site generation and post management from within Emacs.


### PR DESCRIPTION
Created a new Tools page containing the link to the [cobalt.el](https://github.com/accidentalrebel/cobalt.el) Emacs package, as suggested by @epage.

The reason for adding a new page is that it may be possible that other editors (i.e. Vim) will also make interfaces or tools for Cobalt and this is the page to place them.

Right now the page looks sparse but I plan to add a "how to install cobalt.el" as soon as the package ready and submitted to the Emacs package repository, [Melpa](https://github.com/melpa/melpa).