### PR TITLE
fix: prevent <pre> tags from overflowing

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -227,6 +227,7 @@ pre {
   background-color: #f5f5f5;
   border: 1px solid #ccc;
   text-shadow: none;
+  overflow-x: auto;
 }
 
 code {


### PR DESCRIPTION
This patch prevents content in `<pre>` tags from overflowing on the x axis.

This fixes a display bug on the [getting started](http://cobalt-org.github.io/getting-started/) page.

Before:
![screenshot_2018-02-13_10-22-55](https://user-images.githubusercontent.com/1315394/36157747-84fff56a-10a8-11e8-842b-884f7f1ba904.png)

After:
![screenshot_2018-02-13_10-28-09](https://user-images.githubusercontent.com/1315394/36157781-9e090b78-10a8-11e8-9fdf-4d05ba325e07.png)



