### PR TITLE
Add an example for unignoring .well-known/

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -58,6 +58,14 @@ Setting               | Format          | Description
 `ignore`              | List of [Strings](https://git-scm.com/docs/gitignore) | Specifies what files should be ignored by Cobalt by way of a list of [gitignore](https://git-scm.com/docs/gitignore) patterns for, relative to `source`.
 `destination`         | String          | Directory, relative to `_cobalt.yml`, where the output is written to.
 
+For example to unignore the `.well-known/` folder used in LetsEncrypt, add this to your `_cobalt.yml`.
+
+```yaml
+ignore:
+  - "!.well-known"
+  - "!.well-known/**/*"
+```
+
 ### Site options
 
 These are all under `site:` in the yaml:


### PR DESCRIPTION
Used in LetsEncrypt, which is pretty common.

Unignoring things in `.gitignore` is pretty unintuitive, so it's good to
have an example.

Ideally I think this would be in the default `_cobalt.yml`, as I think the default ignoring of `.*` is a bit counter-intuitive. However I get that this may be too much, so having something easily findable in the documentation would be a good second option.