### PR TITLE
feat: add faq page to docs

### DIFF
--- a/_layouts/docs.liquid
+++ b/_layouts/docs.liquid
@@ -33,6 +33,7 @@
             <hr align="left">
             <p>Misc</p>
             <ul>
+              <li><a {% if page.data.route == "faq"%}class="active"{%endif%} href="/docs/faq.html">FAQ</a></li>
               <li><a {% if page.data.route == "rss"%}class="active"{%endif%} href="/docs/rss.html">RSS</a></li>
 	      <li><a {% if page.data.route == "tools"%}class="active"{%endif%} href="/docs/tools.html">Tools</a></li>
               <li><a {% if page.data.route == "deployment"%}class="active"{%endif%} href="/docs/deployment.html">Deployment</a></li>

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,30 @@
+title: "Docs::FAQ"
+layout: docs.liquid
+data:
+  route: faq
+---
+## FAQ
+
+### How can I add MathJax to my pages?
+
+You can include an import for the MathJax library in the `<head>` element of a [layout](/docs/layouts.html). The following code snippet should be plug and play for getting basic MathJax to work in your [pages](/docs/pages.html).
+
+```
+<script type="text/x-mathjax-config">
+  MathJax.Hub.Config({
+    extensions: ["tex2jax.js"],
+    jax: ["input/TeX", "output/HTML-CSS"],
+    tex2jax: {
+      inlineMath: [ ['$','$'], ["\\(","\\)"] ],
+      displayMath: [ ['$$','$$'], ["\\[","\\]"] ],
+      processEscapes: true
+    },
+    "HTML-CSS": { fonts: ["TeX"] }
+  });
+</script>
+<script src='https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.3/latest.js?config=TeX-MML-AM_CHTML' async></script>
+```
+
+After including the above snippet in your [layout](/docs/layouts.html), on any [page](/docs/pages.html) implementing that layout you can surround any text with `$ $` or `$$ $$` to have MathJax render it inline or on a new line, respectively.
+
+You can read more about how to customize or configure MathJax [here](https://docs.mathjax.org/en/latest/configuration.html#configuring-mathjax). If you have further questions or want more information on including MathJax in your Cobalt site, see [this GitHub Issue](https://github.com/cobalt-org/cobalt.rs/issues/280).

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -9,7 +9,7 @@ data:
 
 You can include an import for the MathJax library in the `<head>` element of a [layout](/docs/layouts.html). The following code snippet should be plug and play for getting basic MathJax to work in your [pages](/docs/pages.html).
 
-```
+```html
 <script type="text/x-mathjax-config">
   MathJax.Hub.Config({
     extensions: ["tex2jax.js"],
@@ -27,4 +27,4 @@ You can include an import for the MathJax library in the `<head>` element of a [
 
 After including the above snippet in your [layout](/docs/layouts.html), on any [page](/docs/pages.html) implementing that layout you can surround any text with `$ $` or `$$ $$` to have MathJax render it inline or on a new line, respectively.
 
-You can read more about how to customize or configure MathJax [here](https://docs.mathjax.org/en/latest/configuration.html#configuring-mathjax). If you have further questions or want more information on including MathJax in your Cobalt site, see [this GitHub Issue](https://github.com/cobalt-org/cobalt.rs/issues/280).
+You can read more about how to customize or configure MathJax [here](https://docs.mathjax.org/en/latest/configuration.html#configuring-mathjax). For Cobalt gaining built-in support for MathJax, see [the Github issue](https://github.com/cobalt-org/cobalt.rs/issues/280).


### PR DESCRIPTION
add one faq with instructions on how to include MathJax in a site.

This PR addresses https://github.com/cobalt-org/cobalt.rs/issues/280