### PR TITLE
Update sass support docs

### DIFF
--- a/docs/assets.md
+++ b/docs/assets.md
@@ -12,5 +12,4 @@ These will be mirrored directly in the [`destination`](/docs/config.html) direct
 
 ### Sass
 
-Cobalt has experimental support for Sass.  It requires [installing from
-source](/docs/install.html).
+Cobalt has default support for Sass since v0.12.2.


### PR DESCRIPTION
Unless I'm mistaken, the release v0.12.2 enabled sass support without compiling from source.
 https://github.com/cobalt-org/cobalt.rs/blob/master/CHANGELOG.md#0122-2018-07-21