### PR TITLE
Updating & changing deployment documentation for gitlab

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -64,19 +64,24 @@ cobalt import your site into the `master` branch.
 ### GitLab CI
 
 You can also deploy a cobalt site to [Gitlab Pages](http://pages.gitlab.io/)
-using GitLab CI.  GitLab CI uses [Docker](https://docs.docker.com), you can use
-[nott/cobalt](https://hub.docker.com/r/nott/cobalt/) or any other image with
-`cobalt` in `PATH`.
+using GitLab CI.  GitLab CI uses [Docker](https://docs.docker.com), so there
+are many ways to accomplish building your cobalt site.
 
-An example of `.gitlab-ci.yml`:
+This example `.gitlab-ci.yml` downloads a cobalt release from github, decompresses
+the program, and runs it:
 
 ```yml
-image: nott/cobalt:latest
+image: debian:latest
 
+variables:
+  COBALT_VERSION: "v0.13.2"
 pages:
   script:
+  - apt-get update && apt-get -y install wget tar
+  - wget https://github.com/cobalt-org/cobalt.rs/releases/download/$COBALT_VERSION/cobalt-$COBALT_VERSION-x86_64-unknown-linux-gnu.tar.gz
+  - tar -xf cobalt-$COBALT_VERSION-x86_64-unknown-linux-gnu.tar.gz
   - mkdir -p public
-  - cobalt build -d public
+  - ./cobalt build -d public
   artifacts:
     paths:
     - public/


### PR DESCRIPTION
I was deploying my site with gitlab ci for several months but I found `nott/cobalt` was not updated in 6 months so several new features were not available with this method.

I thought a nice alternative would be to supply the cobalt version myself, which gives the user a bit more control. I ended up using the [releases](https://github.com/cobalt-org/cobalt.rs/releases) from the cobalt github repository.

If this is the wrong direction, no problem, but at least it's here if you like it!