### PR TITLE
fix(li): restore bullets in <li> for content and still hidden in menu

### DIFF
--- a/docs/pages.md
+++ b/docs/pages.md
@@ -6,7 +6,7 @@ data:
 ---
 ## Pages
 
-A page is any file found in the [`source`](/docs/config) directory that
+A page is any file found in the [`source`](/docs/config) directory that:
 - Has an extension in [`template_extensions`](/docs/config)
 - isn't hidden (leading `.` or `_`)
 - isn't excluded through [`ignore`](/docs/config)

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -186,6 +186,11 @@ section.introduction p {
   margin-top: 0;
 }
 
+section.docs aside ul {
+  list-style-type: none;
+  padding: 0;
+}
+
 section.docs aside ul li a {
   display: inline-block;
   margin-bottom: 0.25em;
@@ -219,10 +224,6 @@ section.docs aside ul li a:focus {
   }
 }
 
-section.docs ul {
-  list-style-type: none;
-  padding: 0;
-}
 
 pre {
   display: block;


### PR DESCRIPTION
fix `<li>` (see https://github.com/cobalt-org/cobalt-org.github.io/issues/20)