### PR TITLE
Fixed links in `variables.md` and `usage.md`

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -38,7 +38,7 @@ $ cobalt new "Cats Around the World" --file posts
 $ cobalt new "Cats Around the World" --file posts/cats.md
 ```
 
-You can modify the template used for `new` by editing the files in [`_defaults`](/docs/directory.html).
+You can modify the template used for `new` by editing the files in [`_defaults`](/docs/directory).
 
 ### publish
 

--- a/docs/variables.md
+++ b/docs/variables.md
@@ -30,40 +30,40 @@ Variable     | Format | Description
 -------------|--------|-------------
 `site`       | Object | Site-wide information
 `page`       | Object | Current-page information
-`collection` | Object | Built-in [`posts`](/docs/posts.html).
+`collection` | Object | Built-in [`posts`](/docs/posts).
 
 ### Site Variables
 
 Variable           | Format | Description
 -------------------|--------|------------
-`site.title`       | String | The title of the entire site, see [`_cobalt.yml`](/docs/config.html).
-`site.description` | String | The description of the entire site, see [`_cobalt.yml`](/docs/config.html).
-`site.base_url`    | String | The URL of your site, see [`_cobalt.yml`](/docs/config.html).  This is helpful for making absolute URLs, particularly when run within [`cobalt serve`](/docs/usage.html).
-`site.data`        | Object | The merged result of [`_data`](/docs/directory.html) and [`site: data`](/docs/config.html).
+`site.title`       | String | The title of the entire site, see [`_cobalt.yml`](/docs/config).
+`site.description` | String | The description of the entire site, see [`_cobalt.yml`](/docs/config).
+`site.base_url`    | String | The URL of your site, see [`_cobalt.yml`](/docs/config).  This is helpful for making absolute URLs, particularly when run within [`cobalt serve`](/docs/usage).
+`site.data`        | Object | The merged result of [`_data`](/docs/directory) and [`site: data`](/docs/config).
 
 ### Page Variables
 
-In the context of your [page content](/docs/pages.html):
+In the context of your [page content](/docs/pages):
 
 Variable              | Format          | Description
 ----------------------|-----------------|------------
-`page.permalink`      | String          | Relative path to the page, see [frontmatter](/docs/front.html).
-`page.title`          | String          | The title of the page, see [frontmatter](/docs/front.html).
-`page.slug`           | String          | The identifier of the page, see [frontmatter](/docs/front.html).
-`page.description`    | String          | The description of the page, see [frontmatter](/docs/front.html).
-`page.categories`     | List of Strings | Hierarchical categories this page lives under, see [frontmatter](/docs/front.html).
-`page.published_date` | `YYYY-MM-DD HH:MM:SS TZ` | The date the page was initially published, see [frontmatter](/docs/front.html).
-`page.is_draft`       | Boolean         | See [frontmatter](/docs/front.html).
+`page.permalink`      | String          | Relative path to the page, see [frontmatter](/docs/front).
+`page.title`          | String          | The title of the page, see [frontmatter](/docs/front).
+`page.slug`           | String          | The identifier of the page, see [frontmatter](/docs/front).
+`page.description`    | String          | The description of the page, see [frontmatter](/docs/front).
+`page.categories`     | List of Strings | Hierarchical categories this page lives under, see [frontmatter](/docs/front).
+`page.published_date` | `YYYY-MM-DD HH:MM:SS TZ` | The date the page was initially published, see [frontmatter](/docs/front).
+`page.is_draft`       | Boolean         | See [frontmatter](/docs/front).
 `page.file.permalink` | String          | Relative path to the source file.
 `page.collection`     | String          | The slug of the page's collection.  `"posts"` for posts.
-`page.data`           | Object          | User-defined data, see [frontmatter](/docs/front.html).
+`page.data`           | Object          | User-defined data, see [frontmatter](/docs/front).
 
-Additionally, in the context of your [page layout](/docs/layouts.html):
+Additionally, in the context of your [page layout](/docs/layouts):
 
 Variable       | Format | Description
 ---------------|--------|------------
 `page.content` | String | The rendered page content (i.e. excludes the layout).
-`page.excerpt` | String | The rendered excerpt of a page, see [`excerpt` / `excerpt_separator`](/docs/front.html).
+`page.excerpt` | String | The rendered excerpt of a page, see [`excerpt` / `excerpt_separator`](/docs/front).
 
 ### Collection Variables
 
@@ -71,8 +71,8 @@ Below, the built-in `posts` collection is demonstrated.
 
 Variable                        | Format | Description
 --------------------------------|--------|------------
-`collections.posts.title`       | String | The title of the posts collection, see [`_cobalt.yml`](/docs/config.html).
-`collections.posts.description` | String | The description of the posts collection, see [`_cobalt.yml`](/docs/config.html).
-`collections.posts.slug`        | String | The identifier of the posts collection, see [`_cobalt.yml`](/docs/config.html).
-`collections.posts.rss`         | String | The permalink for the posts' RSS feed, see [`_cobalt.yml`](/docs/config.html) and [RSS](/docs/rss.html).
-`collections.posts.jsonfeed`    | String | The permalink for the posts' RSS feed, see [`_cobalt.yml`](/docs/config.html).
+`collections.posts.title`       | String | The title of the posts collection, see [`_cobalt.yml`](/docs/config).
+`collections.posts.description` | String | The description of the posts collection, see [`_cobalt.yml`](/docs/config).
+`collections.posts.slug`        | String | The identifier of the posts collection, see [`_cobalt.yml`](/docs/config).
+`collections.posts.rss`         | String | The permalink for the posts' RSS feed, see [`_cobalt.yml`](/docs/config) and [RSS](/docs/rss).
+`collections.posts.jsonfeed`    | String | The permalink for the posts' RSS feed, see [`_cobalt.yml`](/docs/config).


### PR DESCRIPTION
One link in `usage.md` and most, if not all, of the links in `variables.md` had the form of `/docs/page_name.html`, causing them to link to a nonexistent page. Each link was changed from `/docs/page_name.html` to `/docs/page_name` in order to redirect to the correct page.

As an example, `/docs/config.html` was changed to `/docs/config`.