### PR TITLE
Add my own blog and the GTRR to the list of example sites

### DIFF
--- a/help.md
+++ b/help.md
@@ -19,6 +19,8 @@ Learn from other site's using cobalt
 - [sda.io](https://sda.io) ([Source](https://github.com/mfs/blog))
 - [booyaa.wtf](https://booyaa.wtf/tags/cobalt/) ([Source](https://github.com/booyaa/booyaa.github.io))
 - [Geob-o-matic](https://haurchefant.fr) ([Source of Cobalt fork](https://github.com/Geobert/blog))
+- [Artemis' Blog](https://artemislena.eu) ([Source](https://codeberg.org/FantasyCookie17/artemislena.eu))
+- [The GTRR](https://gtrr.artemislena.eu) ([Source](https://codeberg.org/FantasyCookie17/gtrr))
 
 ## Issues
 


### PR DESCRIPTION
I've been using Cobalt successfully and have a few templates and such for those two (especially the latter might be interesting; it has a Liquid loop for getting a path like `/you/are/here` with links to the appropriate parent paths), so I thought it could help for extending your documentation as well as helping Cobalt advertising itself ~~(and me advertising my sites)~~ with a longer list of sites…