### PR TITLE
Add macOS installation instructions

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -13,6 +13,9 @@ Cobalt supports Windows, Linux, and Mac.
 **Arch Linux**
 `pacman -S cobalt`
 
+**macOS (with [Homebrew](https://brew.sh)**
+`brew install cobalt`
+
 ### Pre-built Binary
 
 Requirements: *None*


### PR DESCRIPTION
Basically what the title says. Those require [Homebrew](https://brew.sh) to be installed.