### PR TITLE
help.md: add link to water theme

### DIFF
--- a/help.md
+++ b/help.md
@@ -21,6 +21,7 @@ Learn from other site's using cobalt
 - [Geob-o-matic](https://haurchefant.fr) ([Source of Cobalt fork](https://github.com/Geobert/blog))
 - [Artemis' Blog](https://artemislena.eu) ([Source](https://codeberg.org/artemislena/artemislena.eu))
 - [The GTRR](https://gtrr.artemislena.eu) ([Source](https://codeberg.org/artemislena/gtrr))
+- [`water` theme](https://aljazerzen.github.io/cobalt-theme-water/) ([Source](https://github.com/aljazerzen/cobalt-theme-water))
 
 ## Issues
 


### PR DESCRIPTION
I've created a theme based on water.css, this PR adds a link to it.

Not sure how active the Cobalt project still is, but opening this anyway. Is there a roadmap or a "current status" notice?

Even though hugo is quite a hard competitor to beat, I like the simplicity of this project. It still has the potential to do things right, where hugo implemented as half-assed solution.