### PR TITLE
feat(variables): Add documentation for next and previous

### DIFF
--- a/docs/variables.md
+++ b/docs/variables.md
@@ -58,6 +58,8 @@ Variable              | Format          | Description
 `page.file.permalink` | String          | Relative path to the source file.
 `page.collection`     | String          | The slug of the page's collection.  `"posts"` for posts.
 `page.data`           | Object          | User-defined data, see [frontmatter](/docs/front).
+`page.next`           | Object          | Page variables of the next page in the collection. Only available in posts
+`page.previous`       | Object          | Page variables of the previous page in the collection. Only available in posts
 
 Additionally, in the context of your [page layout](/docs/layouts):
 


### PR DESCRIPTION
I discovered on accident today that Cobalt supports referencing the next and previous entries in a collection, which I find super useful for my website. Thought I'd add it to the documentation since it seemed to be missing. If you have thoughts on the exact wording I wouldn't mind amending it; as far as I can tell these are the only two page variables that aren't available to regular pages, which makes it a bit clunky to include in this specific table.